### PR TITLE
Add support for Channel RPC

### DIFF
--- a/example/org/epics/pvdatabase/example/ExampleRPCRecord.java
+++ b/example/org/epics/pvdatabase/example/ExampleRPCRecord.java
@@ -1,0 +1,149 @@
+package org.epics.pvdatabase.example;
+
+import org.epics.pvdata.factory.FieldFactory;
+import org.epics.pvdata.factory.PVDataFactory;
+import org.epics.pvdata.factory.StandardFieldFactory;
+import org.epics.pvdata.pv.FieldBuilder;
+import org.epics.pvdata.pv.FieldCreate;
+import org.epics.pvdata.pv.PVDataCreate;
+import org.epics.pvdata.pv.PVDouble;
+import org.epics.pvdata.pv.PVString;
+import org.epics.pvdata.pv.PVStructure;
+import org.epics.pvdata.pv.PVStructureArray;
+import org.epics.pvdata.pv.Scalar;
+import org.epics.pvdata.pv.ScalarType;
+import org.epics.pvdata.pv.StandardField;
+import org.epics.pvdata.pv.Status.StatusType;
+import org.epics.pvdata.pv.Structure;
+import org.epics.pvdata.pv.StructureArrayData;
+import org.epics.pvaccess.server.rpc.RPCRequestException;
+import org.epics.pvaccess.server.rpc.RPCService;
+import org.epics.pvdatabase.PVDatabase;
+import org.epics.pvdatabase.PVDatabaseFactory;
+import org.epics.pvdatabase.PVRecord;
+
+
+/**
+ * @author Dave Hickin
+ *
+ */
+public class ExampleRPCRecord extends PVRecord {
+    private static final FieldCreate fieldCreate = FieldFactory.getFieldCreate();
+    private static final PVDataCreate pvDataCreate = PVDataFactory.getPVDataCreate();
+    private static final StandardField standardField = StandardFieldFactory.getStandardField();
+
+    private PVStructure pvStructure;
+    private PVDouble    pvx;
+    private PVDouble    pvy;
+    private boolean     underControl = false;
+
+    synchronized boolean takeControl() {
+        if (!underControl) {
+            underControl = true;
+            return true;
+        }
+        return false;
+    }
+
+    synchronized void releaseControl() {
+        underControl = false;
+    }
+
+    static class RPCServiceImpl implements RPCService {
+
+        private ExampleRPCRecord pvRecord;
+
+        RPCServiceImpl(ExampleRPCRecord record) {
+                pvRecord = record;
+        }
+
+	    public PVStructure request(PVStructure args) throws RPCRequestException
+        {
+            boolean haveControl = pvRecord.takeControl();
+            if (!haveControl)
+                throw new RPCRequestException(StatusType.ERROR,
+                "I'm busy");
+
+            PVStructureArray valueField = args.getSubField(PVStructureArray.class,
+                  "value");
+            if (valueField == null)
+                throw new RPCRequestException(StatusType.ERROR,
+                    "No structure array value field");
+
+            Structure valueFieldStructure = valueField.
+                getStructureArray().getStructure();
+
+            Scalar xField = valueFieldStructure.getField(Scalar.class, "x");
+            if (xField == null || xField.getScalarType() != ScalarType.pvDouble)
+                 throw new RPCRequestException(StatusType.ERROR,
+                    "value field's structure has no double field x");
+
+            Scalar yField = valueFieldStructure.getField(Scalar.class, "y");
+            if (yField == null || yField.getScalarType() != ScalarType.pvDouble)
+                 throw new RPCRequestException(StatusType.ERROR,
+                    "value field's structure has no double field y");
+
+            int length = valueField.getLength();
+            StructureArrayData sad = new StructureArrayData();
+            valueField.get(0, length, sad);
+        
+            for (int i = 0; i < length; i++)
+            {
+        	    double x = sad.data[i].getSubField(PVDouble.class, "x").get();
+        	    double y = sad.data[i].getSubField(PVDouble.class, "y").get();
+                pvRecord.put(x,y);
+                try {
+                    Thread.sleep(1000);
+                } catch (Exception e) {
+                    throw new RPCRequestException(StatusType.ERROR,
+                       "Error in thread sleeping");
+                }
+            }
+
+            Structure topStructure = fieldCreate.createFieldBuilder().
+                createStructure();
+
+            PVStructure returned = pvDataCreate.createPVStructure(topStructure);
+            pvRecord.releaseControl();
+            return returned;
+        }
+    }
+
+    public static ExampleRPCRecord create(String recordName)
+    {
+        FieldBuilder fb = fieldCreate.createFieldBuilder();
+        Structure structure = fb.
+            add("x",ScalarType.pvDouble).
+            add("y",ScalarType.pvDouble).
+            add("timeStamp",standardField.timeStamp()).
+            createStructure();
+       ExampleRPCRecord pvRecord = new ExampleRPCRecord(recordName, pvDataCreate.createPVStructure(structure));
+       PVDatabase master = PVDatabaseFactory.getMaster();
+       master.addRecord(pvRecord);
+       return pvRecord;
+    }
+
+    public ExampleRPCRecord(String recordName, PVStructure pvStructure) {
+        super(recordName, pvStructure);
+        this.pvStructure = pvStructure;
+        this.pvx = pvStructure.getSubField(PVDouble.class, "x");
+        this.pvy = pvStructure.getSubField(PVDouble.class, "y");
+        process();
+    }
+
+    private void put(double x, double y)
+    {
+        lock();
+        beginGroupPut();
+        pvx.put(x);
+        pvy.put(y);
+        process();
+        endGroupPut();
+        unlock();
+    }
+
+    public RPCService getService(PVStructure pvRequest)
+    {
+        return new RPCServiceImpl(this);
+    }
+}

--- a/example/org/epics/pvdatabase/example/ExampleRPCRecord.java
+++ b/example/org/epics/pvdatabase/example/ExampleRPCRecord.java
@@ -140,6 +140,10 @@ public class ExampleRPCRecord extends PVRecord {
         process();
         endGroupPut();
         unlock();
+        if(getTraceLevel() > 1)
+        {
+            System.out.println("put(" + x + "," + y + ")");
+        }
     }
 
     public RPCService getService(PVStructure pvRequest)

--- a/example/org/epics/pvdatabase/pva/example/ExampleRPC.java
+++ b/example/org/epics/pvdatabase/pva/example/ExampleRPC.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright - See the COPYRIGHT that is included with this distribution.
+ * EPICS pvData is distributed subject to a Software License Agreement found
+ * in file LICENSE that is included with this distribution.
+ */
+
+package org.epics.pvdatabase.pva.example;
+
+import org.epics.pvdatabase.PVDatabase;
+import org.epics.pvdatabase.PVDatabaseFactory;
+import org.epics.pvdatabase.PVRecord;
+import org.epics.pvdatabase.example.ExampleRPCRecord;
+import org.epics.pvdatabase.pva.ContextLocal;
+
+/**
+ * @author Dave Hickin
+ *
+ */
+public class ExampleRPC {
+    
+    static void usage() {
+        System.out.println("Usage:"
+                + " -recordName name"
+                + " -traceLevel traceLevel"
+                );
+    }
+    
+	private static String recordName = "mydevice";
+	private static int traceLevel = 0;
+	
+	public static void main(String[] args)
+	{
+	    if(args.length==1 && args[0].equals("-help")) {
+	        usage();
+	        return;
+	    }
+	    int nextArg = 0;
+	    while(nextArg<args.length) {
+	        String arg = args[nextArg++];
+	        if(arg.equals("-recordName")) {
+	            recordName = args[nextArg++];
+	            continue;
+	        }
+	        if(arg.equals("-traceLevel")) {
+                traceLevel = Integer.parseInt(args[nextArg++]);
+                continue;
+            } else {
+                System.out.println("Illegal options");
+                usage();
+                return;
+            }
+	    }
+	    PVDatabase master = PVDatabaseFactory.getMaster();    
+	    PVRecord pvRecord = ExampleRPCRecord.create(recordName);
+	    pvRecord.setTraceLevel(traceLevel);
+	    master.addRecord(pvRecord);
+
+	    ContextLocal context = new ContextLocal();
+	    context.start(true);
+	}
+}

--- a/src/org/epics/pvdatabase/PVRecord.java
+++ b/src/org/epics/pvdatabase/PVRecord.java
@@ -22,6 +22,7 @@ import org.epics.pvdata.pv.PostHandler;
 import org.epics.pvdata.pv.Type;
 import org.epics.pvdata.copy.*;
 import org.epics.pvdata.copy.PVCopyTraverseMasterCallback;
+import org.epics.pvaccess.server.rpc.Service;
 
 
 /**
@@ -302,6 +303,15 @@ public class PVRecord implements PVCopyTraverseMasterCallback {
         } finally {
             lock.unlock();
         }
+    }
+    /**
+     * Return a service corresponding to the specified request PVStructure.
+     * @param pvRequest The request PVStructure 
+     * @return The corresponding service
+     */
+    public Service getService(PVStructure pvRequest)
+    {
+        return null;
     }
     /**
      * Begin a group of related puts.

--- a/src/org/epics/pvdatabase/pva/ChannelProviderLocalFactory.java
+++ b/src/org/epics/pvdatabase/pva/ChannelProviderLocalFactory.java
@@ -39,6 +39,11 @@ import org.epics.pvaccess.client.ChannelRPC;
 import org.epics.pvaccess.client.ChannelRPCRequester;
 import org.epics.pvaccess.client.ChannelRequester;
 import org.epics.pvaccess.client.GetFieldRequester;
+import org.epics.pvaccess.server.rpc.RPCRequestException;
+import org.epics.pvaccess.server.rpc.RPCResponseCallback;
+import org.epics.pvaccess.server.rpc.RPCService;
+import org.epics.pvaccess.server.rpc.RPCServiceAsync;
+import org.epics.pvaccess.server.rpc.Service;
 import org.epics.pvdata.copy.PVCopy;
 import org.epics.pvdata.copy.PVCopyFactory;
 import org.epics.pvdata.factory.ConvertFactory;
@@ -407,11 +412,10 @@ public class ChannelProviderLocalFactory  {
          * @see org.epics.pvaccess.client.Channel#createChannelRPC(org.epics.pvaccess.client.ChannelRPCRequester, org.epics.pvdata.pv.PVStructure)
          */
         @Override
-		public ChannelRPC createChannelRPC(
-				ChannelRPCRequester channelRPCRequester, PVStructure pvRequest)
+        public ChannelRPC createChannelRPC(
+                ChannelRPCRequester channelRPCRequester, PVStructure pvRequest)
         {
-            channelRPCRequester.channelRPCConnect(notImplementedStatus,null);
-            return null;
+            return ChannelRPCLocal.create(this, channelRPCRequester, pvRequest, pvRecord);
         }
 		/* (non-Javadoc)
          * @see org.epics.pvaccess.client.Channel#createMonitor(org.epics.pvdata.monitor.MonitorRequester, org.epics.pvdata.pv.PVStructure, org.epics.pvdata.pv.PVStructure)
@@ -911,6 +915,169 @@ public class ChannelProviderLocalFactory  {
             }
         }
         
+    private static class ChannelRPCLocal implements ChannelRPC, RPCResponseCallback
+    {
+        private final Channel channel;
+        private final ChannelRPCRequester channelRPCRequester;
+        private final PVStructure pvRequest;
+        private final PVRecord pvRecord;
+        private volatile boolean lastRequest = false;
+        private final Service service;
+
+        
+        private ChannelRPCLocal(Channel channel, ChannelRPCRequester channelRPCRequester,
+                               PVStructure pvRequest, PVRecord pvRecord, Service service) {
+            this.channel = channel;
+            this.channelRPCRequester = channelRPCRequester;
+            this.pvRequest = pvRequest;
+            this.pvRecord = pvRecord;
+            this.service = service;
+        }
+
+        static ChannelRPCLocal create(
+            ChannelLocal channelLocal,
+            ChannelRPCRequester channelRPCRequester,
+            PVStructure pvRequest,
+            PVRecord pvRecord)
+        {
+            ChannelRPCLocal channelRPC = null;
+            final Service service = pvRecord.getService(pvRequest);
+
+            if (service == null)
+            {
+                channelRPCRequester.channelRPCConnect(notImplementedStatus, null);
+            }
+            else
+            {
+                channelRPC = new ChannelRPCLocal(channelLocal, channelRPCRequester, pvRequest,
+                    pvRecord, service);
+                channelRPCRequester.channelRPCConnect(okStatus,channelRPC);
+            }
+
+            return channelRPC;
+        }
+
+        public void lastRequest()
+        {
+            lastRequest = true;
+        }
+        
+        public Channel getChannel()
+        {
+            return channel;
+        }
+
+        private void processRequest(RPCService rpcService, PVStructure pvArgument)
+        {
+            PVStructure result = null;
+            Status status = okStatus;
+            boolean ok = true;
+            try
+            {
+                result = rpcService.request(pvArgument);
+            }
+            catch (RPCRequestException rre)
+            {
+                status =
+                    statusCreate.createStatus(
+                        rre.getStatus(),
+                        rre.getMessage(),
+                        rre);
+                ok = false;
+            }
+            catch (Throwable th)
+            {
+                // handle user unexpected errors
+                status = 
+                    statusCreate.createStatus(StatusType.FATAL,
+                                "Unexpected exception caught while calling RPCService.request(PVStructure).",
+                                th);
+                ok = false;
+            }
+        
+            // check null result
+            if (ok && result == null)
+            {
+                status =
+                    statusCreate.createStatus(
+                            StatusType.FATAL,
+                            "RPCService.request(PVStructure) returned null.",
+                            null);
+            }
+            
+            channelRPCRequester.requestDone(status, this, result);
+            
+            if (lastRequest)
+                destroy();
+        }
+        
+        @Override
+        public void requestDone(Status status, PVStructure result) {
+            channelRPCRequester.requestDone(status, this, result);
+            
+            if (lastRequest)
+                destroy();
+        }
+        
+        private void processRequest(RPCServiceAsync rpcServiceAsync, PVStructure pvArgument)
+        {
+            try
+            {
+                rpcServiceAsync.request(pvArgument, this);
+            }
+            catch (Throwable th)
+            {
+                // handle user unexpected errors
+                Status status = 
+                    statusCreate.createStatus(StatusType.FATAL,
+                                "Unexpected exception caught while calling RPCService.request(PVStructure).",
+                                th);
+
+                channelRPCRequester.requestDone(status, this, null);
+                
+                if (lastRequest)
+                    destroy();
+            }
+        
+            // we wait for callback to be called
+        }
+
+        @Override
+        public void request(final PVStructure pvArgument) {
+
+            if (service instanceof RPCService)
+            {
+                final RPCService rpcService = (RPCService)service;
+                processRequest(rpcService, pvArgument);
+            }
+            else if (service instanceof RPCServiceAsync)
+            {
+                final RPCServiceAsync rpcServiceAsync = (RPCServiceAsync)service;
+                processRequest(rpcServiceAsync, pvArgument);
+            }
+            else
+                throw new RuntimeException("unsupported Service type");
+        }
+
+        @Override
+        public void destroy() {
+        }
+
+        @Override
+        public void lock() {
+            // noop
+        }
+
+        @Override
+        public void unlock() {
+            // noop
+        }
+
+        @Override
+        public void cancel() {
+        }
+}
+
         private static class ChannelArrayLocal implements ChannelArray {
             private boolean isDestroyed = false;
             private ChannelLocal channelLocal;


### PR DESCRIPTION
Enable pvDatabase channels to support Channel RPC as well as the usual services (Channel Get, Put, Monitor etc.). Adds the equivalent functionality to that in epics-base/pvDatabaseCPP/pull/3.

A new function has been added to PVRecord which returns a service (from the pvAccess RPC library) for a supplied pvRequest. The base class returns a null reference. Derived classes can overide this to implement RPC.

A new ChanneRPClLocal class used by ChannelLocal has been added to support ChannelRPC. This is based on the pvAccess RPC library equivalent, but gets the service form the record and uses pvDatabase trace and follows pvDatabase coding conventions. A null service leads to the original behaviour and so everything is backwards compatible. The service will in general depend on the pvRequest supplied in the channel RPC create, which is a requirement.

A simple example has been added following the pattern of the existing examples. A record has x and y-coordinate fields and a timestamp and also provides a service which sets (x,y) to a sequence of values. This is the equivalent of the example in epics-base/pvDatabaseCPP/pull/3.
